### PR TITLE
Add ESP32-openLIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ SLLIN protocol - that is like slcan protocol for linux based OS.
 
 * [ESP32-LIN-Interface-Library](https://github.com/mestrode/Lin-Interface-Library) - LIN-Master functions (write and request LIN-Frames via hardware UART of an ESP32
 * [open-LIN](https://github.com/open-LIN/open-LIN-c) - Implementation of Local interconnect network in C
+* [ESP32-openLIN](https://github.com/CW-B-W/ESP32-openLIN) - The [open-LIN](https://github.com/open-LIN/open-LIN-c) implementation on ESP32 based on [ESP32-SoftwareLIN](https://github.com/CW-B-W/ESP32-SoftwareLIN)
 
 * []() -
 * []() -


### PR DESCRIPTION
Thanks for this curated list, really helpful for a newbie like me.

The LIN implementation of ESP32 on this list cannot meet my need (most of them only implement LIN Master, no LIN slave), therefore I implement my own one.

Two projects I have made,
* [ESP32-SoftwareLIN](https://github.com/CW-B-W/ESP32-SoftwareLIN), which enable LIN bus serial capability with software emulation on GPIO pins.
* [ESP32-openLIN](https://github.com/CW-B-W/ESP32-openLIN/tree/master), which implements [open-LIN-c](https://github.com/open-LIN/open-LIN-c) on ESP32 with [ESP32-SoftwareLIN](https://github.com/CW-B-W/ESP32-SoftwareLIN).

Hope these can help other newbies.